### PR TITLE
Fix testRetainedOnTopicReturnsWildcardTopicMatch

### DIFF
--- a/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java
+++ b/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java
@@ -22,7 +22,10 @@ import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -76,16 +79,20 @@ public class MemoryRetainedRepositoryTest {
             .payload(Unpooled.buffer(0))
             .build());
 
-        List<RetainedMessage> retainedMessages = repository.retainedOnTopic("foo/bar/#");
+        Map<String, RetainedMessage> retainedMessagesMap = repository.retainedOnTopic("foo/bar/#")
+            .stream()
+            .collect(Collectors.toMap(retainedMessage -> retainedMessage.getTopic().toString(), retainedMessage -> retainedMessage, (a, b) -> a, LinkedHashMap::new));
 
-        assertEquals(1, retainedMessages.size());
-        assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());
+        assertEquals(1, retainedMessagesMap.size());
+        assertTrue(retainedMessagesMap.containsKey("foo/bar/baz"));
 
-        retainedMessages = repository.retainedOnTopic("foo/#");
+        retainedMessagesMap = repository.retainedOnTopic("foo/#")
+            .stream()
+            .collect(Collectors.toMap(retainedMessage -> retainedMessage.getTopic().toString(), retainedMessage -> retainedMessage, (a, b) -> a, LinkedHashMap::new));
 
-        assertEquals(2, retainedMessages.size());
-        assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());
-        assertEquals("foo/baz/bar", retainedMessages.get(1).getTopic().toString());
+        assertEquals(2, retainedMessagesMap.size());
+        assertTrue(retainedMessagesMap.containsKey("foo/bar/baz"));
+        assertTrue(retainedMessagesMap.containsKey("foo/baz/bar"));
     }
 
     @Test


### PR DESCRIPTION
The test [`testRetainedOnTopicReturnsWildcardTopicMatch`](https://github.com/uiuc-cs527-fa23/moquette/blob/9da597415d6cd2b89995d47b46ea8856a12985e6/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java#L58-L89) invokes [`retainedOnTopic`](https://github.com/uiuc-cs527-fa23/moquette/blob/9da597415d6cd2b89995d47b46ea8856a12985e6/broker/src/main/java/io/moquette/broker/MemoryRetainedRepository.java#L54-L65) and stores the returned messages in a list. However, the order in which entries are returned when iterating a Map is implementation-dependent and not guaranteed to be the same. This makes the assertions with fixed indices flaky.

We found and confirmed the flaky behavior using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

This PR fixes the problem using a map to store the retained messages and asserts the messages exist in the map.

You can run the following command to reproduce assertion failures and verify the fix:
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl broker -Dtest=io.moquette.broker.MemoryRetainedRepositoryTest#testRetainedOnTopicReturnsWildcardTopicMatch
```

These two lines in test invoke `retainedOnTopic`
https://github.com/uiuc-cs527-fa23/moquette/blob/9da597415d6cd2b89995d47b46ea8856a12985e6/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java#L79
https://github.com/uiuc-cs527-fa23/moquette/blob/9da597415d6cd2b89995d47b46ea8856a12985e6/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java#L84
`retainedOnTopic` iterates through a `Map` here
https://github.com/uiuc-cs527-fa23/moquette/blob/9da597415d6cd2b89995d47b46ea8856a12985e6/broker/src/main/java/io/moquette/broker/MemoryRetainedRepository.java#L58
Then, the test checks the returned list with fixed indices.
https://github.com/uiuc-cs527-fa23/moquette/blob/9da597415d6cd2b89995d47b46ea8856a12985e6/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java#L81-L82
https://github.com/uiuc-cs527-fa23/moquette/blob/9da597415d6cd2b89995d47b46ea8856a12985e6/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java#L86-L88

Test Environment:
```
openjdk version "11.0.20.1"
Apache Maven 3.6.3
Ubuntu 20.04.6 LTS
Linux version 5.4.0-156-generic
```

Please let me know if you have any concerns or questions.